### PR TITLE
FF36 fix

### DIFF
--- a/src/noscript-nsa/modules/Parent.jsm
+++ b/src/noscript-nsa/modules/Parent.jsm
@@ -207,6 +207,8 @@ function showPresets() {
 
 
 
+this.Parent = Parent;
+
 } catch(e) {
   Cu.reportError(e)
 }

--- a/src/noscript-nsa/modules/Policy.jsm
+++ b/src/noscript-nsa/modules/Policy.jsm
@@ -50,7 +50,7 @@ Policy.getInstance = function() {
     instance = new Policy(this.getPref());
   } catch (e) {
     Cu.reportError(e);
-    Cu.import("resource:noscript_@VERSION@/modules/Defaults.jsm");
+    Cu.import("resource://noscript_@VERSION@/modules/Defaults.jsm");
     instance = Defaults.policy;
   }
 
@@ -62,11 +62,11 @@ Policy.PREF_NAME = "policy";
 Policy.CHANGE_TOPIC = "NoScript:policy-change";
 
 Policy.getPref = function() {
-  Cu.import("resource:noscript_@VERSION@/modules/Prefs.jsm");
+  Cu.import("resource://noscript_@VERSION@/modules/Prefs.jsm");
   return Prefs.get(this.PREF_NAME);
 }
 Policy.storePref = function(policy)  {
-  Cu.import("resource:noscript_@VERSION@/modules/Prefs.jsm");
+  Cu.import("resource://noscript_@VERSION@/modules/Prefs.jsm");
   Prefs.set(this.PREF_NAME, (policy || Policy.getInstance()).serialize());
 }
 

--- a/src/noscript-nsa/modules/Prefs.jsm
+++ b/src/noscript-nsa/modules/Prefs.jsm
@@ -5,9 +5,9 @@ const {interfaces: Ci, classes: Cc, utils: Cu} = Components;
 Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 
-const PACKAGE_NAME = "nsa";
-const PREF_BRANCH = "extensions." + PACKAGE_NAME + ".";
-const prefSvc = Services.prefs;
+this.PACKAGE_NAME = "nsa";
+this.PREF_BRANCH = "extensions." + PACKAGE_NAME + ".";
+this.prefSvc = Services.prefs;
 
 const IPB = Ci.nsIPrefBranch;
 persistPending = false;
@@ -200,7 +200,7 @@ PrefsHelper.prototype = {
   }
 }
 
-const Prefs = new PrefsHelper(PREF_BRANCH);
+this.Prefs = new PrefsHelper(PREF_BRANCH);
 } catch(e) {
   dump(e);
 }


### PR DESCRIPTION
Fix for FF Beta 36 update.

First reported on the forums: https://forums.informaction.com/viewtopic.php?f=25&t=20477

const objects weren't being exported into the global scope.

Changed const to "this." for exported objects in Prefs.jsm.
Created a global instance of Parent object in Parent.jsm.

Added missing forward slashes for import URL's in Policy.jsm